### PR TITLE
Servers support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -225,6 +225,12 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -427,6 +433,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2131b0dabbcf06800b50d95261a93a6cb2535b6372d7a5a4565b5b420767709f"
+  inputs-digest = "29437d54969f64f613b0aee41a37740941df3fede544538ec6a3088654a9b718"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/app/app.go
+++ b/app/app.go
@@ -148,7 +148,11 @@ func (a *App) Run(ctx context.Context) (retErr error) {
 		}
 	}
 
-	generic.Run(ctx)
+	err := generic.Run(ctx)
+	if err != nil {
+		return err
+	}
+
 	return ctx.Err()
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -63,7 +63,6 @@ type App struct {
 	ResyncPeriod         time.Duration
 	Namespace            string
 	Controllers          []ctrl.Constructor
-	Servers              []ctrl.ServerConstructor
 	Workers              int
 	LeaderElectionConfig LeaderElectionConfig
 	AuxListenOn          string
@@ -90,8 +89,6 @@ func (a *App) Run(ctx context.Context) (retErr error) {
 	if err != nil {
 		return err
 	}
-
-	// Construct servers
 
 	// Auxiliary server
 	auxSrv := AuxServer{

--- a/app/app.go
+++ b/app/app.go
@@ -147,13 +147,7 @@ func (a *App) Run(ctx context.Context) (retErr error) {
 		case <-startedLeading:
 		}
 	}
-
-	err := generic.Run(ctx)
-	if err != nil {
-		return err
-	}
-
-	return ctx.Err()
+	return generic.Run(ctx)
 }
 
 func (a *App) startLeaderElection(ctx context.Context, configMapsGetter core_v1client.ConfigMapsGetter, recorder record.EventRecorder) (context.Context, <-chan struct{}, error) {

--- a/app/app.go
+++ b/app/app.go
@@ -63,6 +63,7 @@ type App struct {
 	ResyncPeriod         time.Duration
 	Namespace            string
 	Controllers          []ctrl.Constructor
+	Servers              []ctrl.ServerConstructor
 	Workers              int
 	LeaderElectionConfig LeaderElectionConfig
 	AuxListenOn          string
@@ -89,6 +90,8 @@ func (a *App) Run(ctx context.Context) (retErr error) {
 	if err != nil {
 		return err
 	}
+
+	// Construct servers
 
 	// Auxiliary server
 	auxSrv := AuxServer{

--- a/generic.go
+++ b/generic.go
@@ -36,8 +36,8 @@ type Generic struct {
 }
 
 func NewGeneric(config *Config, queue workqueue.RateLimitingInterface, workers int, constructors ...Constructor) (*Generic, error) {
-	controllers := make(map[schema.GroupVersionKind]Interface, len(constructors))
-	servers := make(map[schema.GroupVersionKind]Server, len(constructors))
+	controllers := make(map[schema.GroupVersionKind]Interface)
+	servers := make(map[schema.GroupVersionKind]Server)
 	holders := make(map[schema.GroupVersionKind]Holder)
 	informers := make(map[schema.GroupVersionKind]cache.SharedIndexInformer)
 	serverHolders := make(map[schema.GroupVersionKind]ServerHolder)

--- a/generic.go
+++ b/generic.go
@@ -161,6 +161,8 @@ func (g *Generic) Run(ctx context.Context) {
 		stage.Start(g.worker)
 	}
 
+	// Start servers here
+
 	<-ctx.Done()
 }
 

--- a/types.go
+++ b/types.go
@@ -3,9 +3,8 @@ package ctrl
 import (
 	"context"
 	"flag"
-	"time"
-
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"

--- a/types.go
+++ b/types.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"time"
 
+	"net/http"
+
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -24,11 +26,23 @@ type Descriptor struct {
 	ZapNameField ZapNameField
 }
 
+type Server interface {
+	Run(context.Context) error
+}
+
+type Constructed struct {
+	// Interface holds an optional controller interface.
+	Interface Interface
+	// Server holds an optional server interface.
+	Server Server
+}
+
 type Constructor interface {
 	AddFlags(*flag.FlagSet)
-	// New constructs a new controller.
-	// It must register an informer for the GVK controller handles via Context.RegisterInformer().
-	New(*Config, *Context) (Interface, error)
+	// New constructs a new controller and/or server.
+	// If it constructs a controller, it must register an informer for the GVK controller
+	// handles via Context.RegisterInformer().
+	New(*Config, *Context) (*Constructed, error)
 	Describe() Descriptor
 }
 
@@ -68,6 +82,8 @@ type Context struct {
 	// process work using it's Process() method. This should be used to delay processing while some initialization
 	// is being performed.
 	ReadyForWork func()
+	// Middleware is the standard middleware that is supposed to be used to wrap the http handler of the server.
+	Middleware func(http.Handler) http.Handler
 	// Will contain all informers once Generic controller constructs all controllers.
 	// This is a read only field, must not be modified.
 	Informers map[schema.GroupVersionKind]cache.SharedIndexInformer


### PR DESCRIPTION
Added support for the controller constructor to create an optional server object and support injecting middleware into the server for basic request count metrics. This changes the behaviour slightly because the controller and informer now become optional.