### PR TITLE
gometalinter: increase deadline

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,7 +1,7 @@
 {
   "Concurrency": 4,
   "Cyclo": 15,
-  "Deadline": "2m",
+  "Deadline": "5m",
   "Disable": [
     "interfacer"
   ],


### PR DESCRIPTION
- master is failing Travis CI builds

```
gometalinter.v2 ./...
WARNING: deadline exceeded by linter varcheck (try increasing --deadline)
```

- so, this PR increases the deadline from 2 minutes to 5 minutes