### PR TITLE
Renamed a bunch of metrics

### DIFF
--- a/generic_worker.go
+++ b/generic_worker.go
@@ -61,6 +61,9 @@ func (g *Generic) handleErr(logger *zap.Logger, retriable bool, err error, key g
 }
 
 func (g *Generic) processKey(logger *zap.Logger, holder Holder, key gvkQueueKey) (bool /*retriable*/, error) {
+	groupKind := key.gvk.GroupKind()
+	objectName := groupKind.String()
+
 	cntrlr := holder.Cntrlr
 	informer := g.Informers[key.gvk]
 	obj, exists, err := getFromIndexer(informer.GetIndexer(), key.gvk, key.Namespace, key.Name)
@@ -77,7 +80,7 @@ func (g *Generic) processKey(logger *zap.Logger, holder Holder, key gvkQueueKey)
 	msg := ""
 	defer func() {
 		totalTime := time.Since(startTime)
-		holder.objectProcessTime.Observe(totalTime.Seconds())
+		holder.objectProcessTime.WithLabelValues(holder.AppName, objectName).Observe(totalTime.Seconds())
 		logger.Sugar().Infof("Synced in %v%s", totalTime, msg)
 	}()
 

--- a/generic_worker.go
+++ b/generic_worker.go
@@ -62,7 +62,6 @@ func (g *Generic) handleErr(logger *zap.Logger, retriable bool, err error, key g
 
 func (g *Generic) processKey(logger *zap.Logger, holder Holder, key gvkQueueKey) (bool /*retriable*/, error) {
 	groupKind := key.gvk.GroupKind()
-	objectName := groupKind.String()
 
 	cntrlr := holder.Cntrlr
 	informer := g.Informers[key.gvk]
@@ -80,7 +79,7 @@ func (g *Generic) processKey(logger *zap.Logger, holder Holder, key gvkQueueKey)
 	msg := ""
 	defer func() {
 		totalTime := time.Since(startTime)
-		holder.objectProcessTime.WithLabelValues(holder.AppName, objectName).Observe(totalTime.Seconds())
+		holder.objectProcessTime.WithLabelValues(holder.AppName, key.Namespace, key.Name, groupKind.String()).Observe(totalTime.Seconds())
 		logger.Sugar().Infof("Synced in %v%s", totalTime, msg)
 	}()
 

--- a/generic_worker.go
+++ b/generic_worker.go
@@ -67,7 +67,7 @@ func (g *Generic) processKey(logger *zap.Logger, holder Holder, key gvkQueueKey)
 	informer := g.Informers[key.gvk]
 	obj, exists, err := getFromIndexer(informer.GetIndexer(), key.gvk, key.Namespace, key.Name)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to get object by key %s", key)
+		return false, errors.Wrapf(err, "failed to get object by key %s", key.String())
 	}
 	if !exists {
 		logger.Debug("Object not in cache. Was deleted?")


### PR DESCRIPTION
The metrics are crap because

* Histogram already provides count
* Some of the metrics aren't even namespaced properly
* The metric names are too long and make life difficult when you try to use prometheus to do fancy filtering

I renamed a bunch of things to make things less crap