### PR TITLE
More metrics for tracking errors coming out of controller

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -128,8 +128,7 @@ func NewGeneric(config *Config, queue workqueue.RateLimitingInterface, workers i
 				objectProcessErrors: objectProcessErrors,
 			}
 
-			allMetrics = append(allMetrics, objectProcessTime)
-			allMetrics = append(allMetrics, objectProcessErrors)
+			allMetrics = append(allMetrics, objectProcessTime, objectProcessErrors)
 		}
 
 		if constructed.Server != nil {

--- a/generic_worker.go
+++ b/generic_worker.go
@@ -1,6 +1,7 @@
 package ctrl
 
 import (
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -91,6 +92,9 @@ func (g *Generic) processKey(logger *zap.Logger, holder Holder, key gvkQueueKey)
 		msg = " (conflict)"
 		err = nil
 	}
+	holder.objectProcessErrors.
+		WithLabelValues(holder.AppName, key.Namespace, key.Name, groupKind.String(), strconv.FormatBool(retriable)).
+		Inc()
 	return retriable, err
 }
 


### PR DESCRIPTION
This depends on the other PR I made.

I added another metric which is for the number of errors coming out of the controller.

This is useful because in Voyager:

1. Resource errors are generally shoved into conditions
2. All other internal errors get shoved into the stack trace (including temporary network blips and "Bundle is marked for deletion" sort of errors.

This is good for alerting because we can now compare if "ratio of errors to number of state processed for a single object > 0.5" or something like that, which can highlight if the network is dead or something is stuck in deletion permanently or something like that.