### PR TITLE
Add error handling for logger.Sync

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -75,7 +75,7 @@ type App struct {
 func (a *App) Run(ctx context.Context) (retErr error) {
 	defer func() {
 		if err := a.Logger.Sync(); err != nil {
-			fmt.Printf("Failed to flush (AKA sync) remaining logs: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Failed to flush (AKA sync) remaining logs: %v\n", err)
 		}
 	}()
 

--- a/app/app.go
+++ b/app/app.go
@@ -75,7 +75,7 @@ type App struct {
 func (a *App) Run(ctx context.Context) (retErr error) {
 	defer func() {
 		if err := a.Logger.Sync(); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to flush (AKA sync) remaining logs: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Failed to flush (AKA sync) remaining logs: %v\n", err) // nolint: errcheck
 		}
 	}()
 

--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -72,8 +73,11 @@ type App struct {
 }
 
 func (a *App) Run(ctx context.Context) (retErr error) {
-	defer a.Logger.Sync() // nolint: errcheck
-	// unhandled error above, but we are terminating anyway
+	defer func() {
+		if err := a.Logger.Sync(); err != nil {
+			fmt.Printf("Failed to flush (AKA sync) remaining logs: %s\n", err.Error())
+		}
+	}()
 
 	// Controller
 	config := &ctrl.Config{

--- a/app/app.go
+++ b/app/app.go
@@ -75,7 +75,7 @@ type App struct {
 func (a *App) Run(ctx context.Context) (retErr error) {
 	defer func() {
 		if err := a.Logger.Sync(); err != nil {
-			fmt.Printf("Failed to flush (AKA sync) remaining logs: %s\n", err.Error())
+			fmt.Printf("Failed to flush (AKA sync) remaining logs: %v\n", err)
 		}
 	}()
 


### PR DESCRIPTION
I thought we could handle this error, just in case we might get a problem in the future with syncing logs. Also removes a nolint comment, and a why-we-did-that comment. Thoughts?