### PR TITLE
Make LeaderElectionConfig a pointer in App struct

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -248,7 +248,7 @@ func NewFromFlags(name string, controllers []ctrl.Constructor, flagset *flag.Fla
 		"of a leadership. This is only applicable if leader election is enabled")
 	flagset.StringVar(&a.LeaderElectionConfig.ConfigMapNamespace, "leader-elect-configmap-namespace", meta_v1.NamespaceDefault,
 		"Namespace to use for leader election ConfigMap. This is only applicable if leader election is enabled")
-	flagset.StringVar(&a.LeaderElectionConfig.ConfigMapName, "leader-elect-configmap-name", name+"-leader-elect",
+	flagset.StringVar(&a.LeaderElectionConfig.ConfigMapName, "leader-elect-configmap-name", name+":leader-elect",
 		"ConfigMap name to use for leader election. This is only applicable if leader election is enabled")
 	configFileFrom := flagset.String("client-config-from", "in-cluster",
 		"Source of REST client configuration. 'in-cluster' (default), 'environment' and 'file' are valid options.")

--- a/app/app.go
+++ b/app/app.go
@@ -64,7 +64,7 @@ type App struct {
 	Namespace            string
 	Controllers          []ctrl.Constructor
 	Workers              int
-	LeaderElectionConfig LeaderElectionConfig
+	LeaderElectionConfig *LeaderElectionConfig
 	AuxListenOn          string
 	Debug                bool
 }
@@ -213,8 +213,9 @@ func CancelOnInterrupt(ctx context.Context, f context.CancelFunc) {
 
 func NewFromFlags(name string, controllers []ctrl.Constructor, flagset *flag.FlagSet, arguments []string) (*App, error) {
 	a := App{
-		Name:        name,
-		Controllers: controllers,
+		Name:                 name,
+		Controllers:          controllers,
+		LeaderElectionConfig: &LeaderElectionConfig{},
 	}
 	for _, cntrlr := range controllers {
 		cntrlr.AddFlags(flagset)


### PR DESCRIPTION
Bug: flags for leader election have no effect due to `LeaderElectionConfig` being a value rather than a pointer in the `App` struct, as when we do things like
```go
	flagset.StringVar(&a.LeaderElectionConfig.ConfigMapName, "leader-elect-configmap-name", name+"-leader-elect",
		"ConfigMap name to use for leader election. This is only applicable if leader election is enabled")
```
we actually mutate a copy of `LeaderElectionConfig` object with the flags rather than the one from `App`.