### PR TITLE
We don't use multiple controllers in a binary

### DIFF
--- a/logz/logz.go
+++ b/logz/logz.go
@@ -8,13 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// ControllerGk is a zap field used to identify logs coming from a specific controller
-// or controller constructor. It includes logs that don't involve processing an
-// object.
-func ControllerGk(gk schema.GroupKind) zapcore.Field {
-	return zap.Stringer("ctrl_gk", &gk)
-}
-
 // Object returns a zap field used to record ObjectName.
 func Object(obj meta_v1.Object) zapcore.Field {
 	return ObjectName(obj.GetName())

--- a/process/generic.go
+++ b/process/generic.go
@@ -53,7 +53,7 @@ func NewGeneric(config *ctrl.Config, queue workqueue.RateLimitingInterface, work
 		readyForWork := make(chan struct{})
 		queueGvk := wq.newQueueForGvk(descr.Gvk)
 		groupKind := descr.Gvk.GroupKind()
-		controllerLogger := config.Logger.With(logz.ControllerGk(groupKind))
+		controllerLogger := config.Logger
 		constructorConfig := config
 		constructorConfig.Logger = controllerLogger
 

--- a/process/generic_worker.go
+++ b/process/generic_worker.go
@@ -39,7 +39,6 @@ func (g *Generic) processNextWorkItem() bool {
 
 	holder := g.Controllers[key.gvk]
 	logger := g.logger.With(logz.NamespaceName(key.Namespace),
-		logz.ControllerGk(key.gvk.GroupKind()),
 		logz.ObjectName(key.Name),
 		logz.ObjectGk(key.gvk.GroupKind()),
 		logz.Iteration(atomic.AddUint32(&g.iter, 1)))


### PR DESCRIPTION
This allows to significantly reduce log volume.