### PR TITLE
Change log levels for errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -604,6 +604,7 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/util/errors",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/rest",

--- a/process/generic_worker.go
+++ b/process/generic_worker.go
@@ -44,22 +44,29 @@ func (g *Generic) processNextWorkItem() bool {
 		logz.Iteration(atomic.AddUint32(&g.iter, 1)))
 
 	retriable, err := g.processKey(logger, holder, key)
-	g.handleErr(logger, retriable, err, key)
+	g.handleErr(logger, holder, retriable, err, key)
 
 	return true
 }
 
-func (g *Generic) handleErr(logger *zap.Logger, retriable bool, err error, key gvkQueueKey) {
+func (g *Generic) handleErr(logger *zap.Logger, holder Holder, retriable bool, err error, key gvkQueueKey) {
 	if err == nil {
 		g.queue.forget(key)
 		return
 	}
+
 	if retriable && g.queue.numRequeues(key) < maxRetries {
 		logger.Info("Error syncing object, will retry", zap.Error(err))
 		g.queue.addRateLimited(key)
+		holder.objectProcessErrors.
+			WithLabelValues(holder.AppName, key.Namespace, key.Name, groupKind.String(), strconv.FormatBool(true)).
+			Inc()
 		return
 	}
 
+	holder.objectProcessErrors.
+		WithLabelValues(holder.AppName, key.Namespace, key.Name, groupKind.String(), strconv.FormatBool(false)).
+		Inc()
 	logger.Error("Dropping object out of the queue", zap.Error(err))
 	g.queue.forget(key)
 }
@@ -94,11 +101,6 @@ func (g *Generic) processKey(logger *zap.Logger, holder Holder, key gvkQueueKey)
 	if err != nil && api_errors.IsConflict(errors.Cause(err)) {
 		msg = " (conflict)"
 		err = nil
-	}
-	if err != nil {
-		holder.objectProcessErrors.
-			WithLabelValues(holder.AppName, key.Namespace, key.Name, groupKind.String(), strconv.FormatBool(retriable)).
-			Inc()
 	}
 	return retriable, err
 }

--- a/process/generic_worker.go
+++ b/process/generic_worker.go
@@ -54,11 +54,7 @@ func (g *Generic) handleErr(logger *zap.Logger, retriable bool, err error, key g
 		g.queue.forget(key)
 		return
 	}
-	if retriable {
-		if g.queue.numRequeues(key) >= maxRetries {
-			logger.Warn("Exceeded maximum retries, dropping object out of the queue", zap.Error(err))
-			return
-		}
+	if retriable && g.queue.numRequeues(key) < maxRetries {
 		logger.Info("Error syncing object, will retry", zap.Error(err))
 		g.queue.addRateLimited(key)
 		return


### PR DESCRIPTION
This changes the log level for errors to be Error.

It also changes our metrics to post retriable errors which have hit the limit of retries as "non-retriable" because these errors are no longer retriable (makes sense)?